### PR TITLE
updates to initial.js version 0.2.0

### DIFF
--- a/lib/initialjs-rails/version.rb
+++ b/lib/initialjs-rails/version.rb
@@ -1,3 +1,3 @@
 module InitialjsRails
-  VERSION = "0.1.0"
+  VERSION = "0.2.0"
 end

--- a/lib/initialjs-rails/view_helpers.rb
+++ b/lib/initialjs-rails/view_helpers.rb
@@ -6,8 +6,10 @@ module InitialjsRails
       size          = options.fetch(:size)          { 100 }
       klass         = options.fetch(:class)         { '' }
       round_corners = options.fetch(:round_corners) { true }
+      seed          = options.fetch(:seed)          { 0 }
 
       data_attributes = { name: avatarable.name,
+        seed: seed,
         height: size,
         width: size,
         "font-size" => (size * 0.6) }

--- a/vendor/assets/javascripts/initial.js
+++ b/vendor/assets/javascripts/initial.js
@@ -10,6 +10,7 @@
             var settings = $.extend({
                 // Default settings
                 name: 'Name',
+                seed: 0,
                 charCount: 1,
                 textColor: '#ffffff',
                 height: 100,
@@ -37,7 +38,7 @@
                 'font-size': settings.fontSize+'px',
             });
 
-            var colorIndex = Math.floor((c.charCodeAt(0) - 65) % colors.length);
+            var colorIndex = Math.floor((c.charCodeAt(0) + settings.seed) % colors.length);
 
             var svg = $('<svg></svg>').attr({
                 'xmlns': 'http://www.w3.org/2000/svg',


### PR DESCRIPTION
initial.js version 0.2.0 has a new `:seed` option.
This PR updates initialjs-rails to that version.

A new gem release would be great to use it you-know-where :)
