### PR TITLE
Prevents close img tags

### DIFF
--- a/lib/initialjs-rails/view_helpers.rb
+++ b/lib/initialjs-rails/view_helpers.rb
@@ -22,7 +22,7 @@ module InitialjsRails
 
       data_attributes.merge!(radius: (size * 0.13).round) if round_corners
 
-      content_tag :img, nil, alt: get_name(avatarable), class: "initialjs-avatar #{klass}".strip, data: data_attributes
+      tag(:img, {alt: get_name(avatarable), class: "initialjs-avatar #{klass}".strip, data: data_attributes}, true, false)
     end
 
     def get_name_with_count(avatarable, count)


### PR DESCRIPTION
Prevents close `<img>` tags when use `<%= avatar_image %>` and avoid HTML validation error. 😉 