### PR TITLE
Adds src option

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ For extra simplicity, you can use this helper in your view to generate your avat
     avatar_image(user, round_corners: false) # => disable round corners
     avatar_image(user, count: 2)             # => Number of characters shown in the image
     avatar_image(user, color: 'black')       # => Text color black. You can also provide any color in hex format: #000
+    avatar_image(user, src: some_path)       # => Adds src of alternative image for browser does not support SVG
 
 ## Development
 

--- a/lib/initialjs-rails/view_helpers.rb
+++ b/lib/initialjs-rails/view_helpers.rb
@@ -9,6 +9,7 @@ module InitialjsRails
       seed          = options.fetch(:seed)          { 0 }
       char_count    = options.fetch(:count)         { 1 }
       txt_color     = options.fetch(:color)         { '#ffffff' }
+      initial_src   = options.fetch(:src)           { '' }
 
       data_attributes = {
         name:         get_name_with_count(avatarable, char_count),
@@ -22,7 +23,7 @@ module InitialjsRails
 
       data_attributes.merge!(radius: (size * 0.13).round) if round_corners
 
-      tag(:img, {alt: get_name(avatarable), class: "initialjs-avatar #{klass}".strip, data: data_attributes}, true, false)
+      tag(:img, {alt: get_name(avatarable), class: "initialjs-avatar #{klass}".strip, data: data_attributes, src: initial_src}, true, false)
     end
 
     def get_name_with_count(avatarable, count)


### PR DESCRIPTION
Adds src of alternative image for browser does not support SVG.

Also avoid the validation error: `Element <img> is missing required attribute "src".` 

When uses initial-js the code generated its:
`<img src="data:image/svg+xml;base64...` so you can specifies an alternative path and also avoid the validation error `empty attribute src`