### PR TITLE
Change railties from "< 6.0" to "< 7.0"

### DIFF
--- a/initialjs-rails.gemspec
+++ b/initialjs-rails.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'railties', [">= 3.1", "< 6.0"]
+  spec.add_dependency 'railties', [">= 3.1", "< 7.0"]
 
   spec.add_development_dependency "bundler", "~> 1.9"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
This change allows this gem to be installed to Rails 6.0 environment.