### PR TITLE
Change railties from "< 7.0" to "< 8.0"

### DIFF
--- a/initialjs-rails.gemspec
+++ b/initialjs-rails.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'railties', [">= 3.1", "< 7.0"]
+  spec.add_dependency 'railties', [">= 3.1", "< 8.0"]
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake", ">= 12.3.3"


### PR DESCRIPTION
Allow this gem to be installed in Rails 7